### PR TITLE
Integrate with the latest libtac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@
 
 # Debug files
 *.dSYM/
+
+# Build dirs
+bin
+

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 TARGET=		libnss_tacplus.so.2
 TEST_TARGET=	bin/dlharness
-LIBS=		-lnsl -lpthread -ltac
+#LIBS=		-lnsl -lpthread -ltac
+LIBS=		-lpthread -ltac
 TEST_LIBS=	-ldl
 
 CC=	gcc
-CFLAGS=	-D_FORTIFY_SOURCE=2 -O -fstack-protector -std=gnu99 -Werror -Wall \
+CFLAGS+=	-D_FORTIFY_SOURCE=2 -O -fstack-protector -std=gnu99 -Werror -Wall \
 	-ggdb -fPIC -I/usr/local/lib
-LDFLAGS=-shared -Wl,-soname,libnss_tacplus.so.2 -Wl,-rpath=/usr/local/lib
+LDFLAGS+=-shared -Wl,-soname,libnss_tacplus.so.2 -Wl,-rpath=/usr/local/lib
 
 
 OBJECTS=$(patsubst %.c, %.o, $(wildcard src/*.c))
@@ -27,11 +28,11 @@ test: $(TEST_TARGET)
 .PRECIOUS: $(TARGET) $(TEST_TARGET) (OBJECTS)
 
 $(TARGET): $(OBJECTS)
-	$(CC) $(OBJECTS) $(LIBS) $(LDFLAGS) -o $@
+	$(CC) $(OBJECTS) $(LDFLAGS) $(LIBS) -o $@
 
 $(TEST_TARGET): $(TEST_OBJECTS)
 	-mkdir -p bin
-	$(CC) $(TEST_OBJECTS) $(TEST_LIBS) $(TEST_LDFLAGS) -o $@
+	$(CC) $(TEST_OBJECTS) $(TEST_LDFLAGS) $(TEST_LIBS) -o $@
 
 clean:
 	-rm -f src/*.o test/*.o

--- a/etc/tacplus.conf
+++ b/etc/tacplus.conf
@@ -1,7 +1,6 @@
-server 10.0.0.1
-secret password
+server 10.0.0.1 secret password
 timeout 2
-debug 1
+debug-level 1
 service linuxlogin
 protocol ssh
 default-hashed-uid yes


### PR DESCRIPTION
1. Fix compilation errors and warnings
2. Support areply->attr's new type (gl_list_t instead of struct tac_attrib)
3. Makefile: extend CFLAGS+LDFLAGS from environment variables
4. Fix typo in example configuration file etc/tacplus.conf

Note, project does not compile with just "make" command, I ended up with this one:
```
> CFLAGS="-I../pam_tacplus -I/usr/share/gnulib/lib -DHAVE_CONFIG_H" make
```
In other words, build uses config.h from pam_tacplus and it requires gl_list.h from gnulib to be available, which tends to be a horrible workaround.
